### PR TITLE
Updates for 2021 rustc and deps compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,26 @@
 [package]
 name = "shib-gotham"
-version = "0.2.0-dev"
+version = "0.2.1"
 authors = ["Shaun Mangelsdorf <s.mangelsdorf@gmail.com>",
            "Bradley Beddoes <bradleybeddoes@gmail.com>"]
 
 [dependencies]
-log = "0.4.0"
-futures = "0.1.0"
+log = "0.4.14"
+futures = "0.1"
 hyper = "0.11"
 serde = "1.0"
 serde_derive = "1.0"
-percent-encoding = "1.0"
-gotham = "0.3.0-dev"
-gotham_derive = "0.3.0-dev"
+percent-encoding = "1.0.1"
+gotham = "0.2.1"
+gotham_derive = "0.2.1"
 
 [dev-dependencies]
 tokio-core = "0.1"
-serde_bytes = "0.10"
+serde_bytes = "0.11.5"
 mime = "*"
 fern = "*"
 chrono = "*"
 
 [patch.crates-io]
-gotham = { git = "https://github.com/gotham-rs/gotham" }
-gotham_derive = { git = "https://github.com/gotham-rs/gotham" }
-
+gotham = { git = "https://github.com/gotham-rs/gotham", tag = "0.2.1"  }
+gotham_derive = { git = "https://github.com/gotham-rs/gotham", tag = "0.2.1"  }

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -1,10 +1,9 @@
 mod deserialize_headers;
 mod deserialize_values;
 
-use std::{error, fmt};
-use std::error::Error;
-use serde::de::{self, Deserialize};
 use hyper::Headers;
+use serde::de::{self, Deserialize};
+use std::{error, fmt};
 
 #[derive(Debug)]
 pub(crate) enum HeadersDeserializationError {
@@ -34,9 +33,7 @@ impl de::Error for HeadersDeserializationError {
 
 impl fmt::Display for HeadersDeserializationError {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
-        out.write_str("HeadersDeserializationError(")?;
-        out.write_str(self.description())?;
-        out.write_str(")")
+        fmt::Debug::fmt(self, out)
     }
 }
 
@@ -55,8 +52,8 @@ mod tests {
 
     use std::collections::HashMap;
 
-    use serde_bytes;
     use hyper::Headers;
+    use serde_bytes;
 
     #[test]
     fn test_deserialize_unit() {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -3,15 +3,15 @@ use std::marker::PhantomData;
 use std::panic::RefUnwindSafe;
 
 use futures::future;
-use hyper::{StatusCode, Uri};
 use hyper::header::Location;
+use hyper::{StatusCode, Uri};
 use percent_encoding::{utf8_percent_encode, QUERY_ENCODE_SET};
 
-use gotham::state::{FromState, State};
 use gotham::handler::HandlerFuture;
 use gotham::http::response::create_response;
-use gotham::middleware::{Middleware, NewMiddleware};
 use gotham::middleware::session::SessionData;
+use gotham::middleware::{Middleware, NewMiddleware};
+use gotham::state::{FromState, State};
 
 use authenticated_session::AuthenticatedSession;
 
@@ -27,7 +27,7 @@ where
     T: AuthenticatedSession,
 {
     auth_login_location: &'static str,
-    phantom: PhantomData<SessionTypePhantom<T>>,
+    phantom: PhantomData<dyn SessionTypePhantom<T>>,
 }
 
 impl<T> Shibbleware<T>
@@ -42,11 +42,7 @@ where
     }
 }
 
-impl<T> Copy for Shibbleware<T>
-where
-    T: AuthenticatedSession,
-{
-}
+impl<T> Copy for Shibbleware<T> where T: AuthenticatedSession {}
 
 impl<T> Clone for Shibbleware<T>
 where

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,13 +1,13 @@
-use std::io;
-use std::marker::PhantomData;
-use std::panic::RefUnwindSafe;
 use futures::future;
-use hyper::{Headers, Response, StatusCode};
-use hyper::header::Location;
-use serde::Deserialize;
 use gotham::handler::{Handler, HandlerFuture, NewHandler};
 use gotham::http::response::create_response;
 use gotham::state::{request_id, FromState, State};
+use hyper::header::Location;
+use hyper::{Headers, Response, StatusCode};
+use serde::Deserialize;
+use std::io;
+use std::marker::PhantomData;
+use std::panic::RefUnwindSafe;
 
 use headers::deserialize;
 
@@ -58,7 +58,7 @@ where
     A: for<'de> Deserialize<'de> + 'static,
 {
     r: R,
-    phantom: PhantomData<AttributesTypePhantom<A>>,
+    phantom: PhantomData<dyn AttributesTypePhantom<A>>,
 }
 
 impl<A, R> LoginHandler<A, R>


### PR DESCRIPTION
This library hasn't been touched since ~2017 and in order to compile ITP on the latest Rust in order to make changes to it this had to be updated.

Changes here are essentially only to support latest rustc release (1.50) and to update dependencies accordingly, there is no actual logic change.